### PR TITLE
fix: don't use required code in assert

### DIFF
--- a/src/main/java/org/codejive/properties/Cursor.java
+++ b/src/main/java/org/codejive/properties/Cursor.java
@@ -168,4 +168,9 @@ public class Cursor {
     public Cursor copy() {
         return Cursor.index(tokens, index);
     }
+
+    @Override
+    public String toString() {
+        return (hasToken() ? token() + " " : "") + "@" + position();
+    }
 }

--- a/src/test/java/org/codejive/properties/TestProperties.java
+++ b/src/test/java/org/codejive/properties/TestProperties.java
@@ -305,18 +305,26 @@ public class TestProperties {
     @Test
     void testPutNull() throws IOException, URISyntaxException {
         Properties p = new Properties();
-        assertThatThrownBy(() -> {
-            p.put("one", null);
-        }).isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> {
-            p.setProperty("one", null);
-        }).isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> {
-            p.put(null, "value");
-        }).isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> {
-            p.setProperty(null, "value");
-        }).isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(
+                        () -> {
+                            p.put("one", null);
+                        })
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(
+                        () -> {
+                            p.setProperty("one", null);
+                        })
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(
+                        () -> {
+                            p.put(null, "value");
+                        })
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(
+                        () -> {
+                            p.setProperty(null, "value");
+                        })
+                .isInstanceOf(NullPointerException.class);
     }
 
     @Test


### PR DESCRIPTION
Replaced the usage of asserts with a new method called `validate()`.

Fixes #6