### PR TITLE
fix: fixes problems with missing or multiple delimiters

### DIFF
--- a/src/test/java/org/codejive/properties/TestProperties.java
+++ b/src/test/java/org/codejive/properties/TestProperties.java
@@ -671,6 +671,26 @@ public class TestProperties {
         assertThat(c.prevCount(t -> true)).isEqualTo(p.last().position() + 1);
     }
 
+    @Test
+    void testMissingDelim() throws IOException, URISyntaxException {
+        Properties p = Properties.loadProperties(getResource("/test-missingdelim.properties"));
+        assertThat(p).containsOnlyKeys("A-string-without-delimiter");
+        assertThat(p).containsEntry("A-string-without-delimiter", "");
+        StringWriter sw = new StringWriter();
+        p.store(sw);
+        assertThat(sw.toString()).isEqualTo(readAll(getResource("/test-missingdelim.properties")));
+    }
+
+    @Test
+    void testMultiDelim() throws IOException, URISyntaxException {
+        Properties p = Properties.loadProperties(getResource("/test-multidelim.properties"));
+        assertThat(p).containsOnlyKeys("key");
+        assertThat(p).containsEntry("key", "==value");
+        StringWriter sw = new StringWriter();
+        p.store(sw);
+        assertThat(sw.toString()).isEqualTo(readAll(getResource("/test-multidelim.properties")));
+    }
+
     private Path getResource(String name) throws URISyntaxException {
         return Paths.get(getClass().getResource(name).toURI());
     }

--- a/src/test/java/org/codejive/properties/TestPropertiesParser.java
+++ b/src/test/java/org/codejive/properties/TestPropertiesParser.java
@@ -30,6 +30,8 @@ public class TestPropertiesParser {
                     + "    two  \\\r\n"
                     + "\tthree\n"
                     + "key.4 = \\u1234\r\n"
+                    + "line-with-missing-delim  \n"
+                    + "multidelim===value\n"
                     + "  # final comment";
 
     @Test
@@ -81,6 +83,14 @@ public class TestPropertiesParser {
                         new Token(Type.SEPARATOR, " = "),
                         new Token(Type.VALUE, "\\u1234", "\u1234"),
                         new Token(Type.WHITESPACE, "\r\n"),
+                        new Token(Type.KEY, "line-with-missing-delim"),
+                        new Token(Type.SEPARATOR, "  "),
+                        new Token(Type.VALUE, ""),
+                        new Token(Type.WHITESPACE, "\n"),
+                        new Token(Type.KEY, "multidelim"),
+                        new Token(Type.SEPARATOR, "="),
+                        new Token(Type.VALUE, "==value"),
+                        new Token(Type.WHITESPACE, "\n"),
                         new Token(Type.WHITESPACE, "  "),
                         new Token(Type.COMMENT, "# final comment"));
     }

--- a/src/test/resources/test-missingdelim.properties
+++ b/src/test/resources/test-missingdelim.properties
@@ -1,0 +1,1 @@
+A-string-without-delimiter

--- a/src/test/resources/test-multidelim.properties
+++ b/src/test/resources/test-multidelim.properties
@@ -1,0 +1,1 @@
+key===value


### PR DESCRIPTION
A missing delimiter would cause the parser to hang in a loop and cause
a OOM error, while multiple delimiters would cause the parser to
incorrectly parse the line,

Fixes https://github.com/codejive/java-properties/issues/20