### PR TITLE
Introduce `putAll(Properties)`

### DIFF
--- a/src/main/java/org/codejive/properties/Properties.java
+++ b/src/main/java/org/codejive/properties/Properties.java
@@ -774,6 +774,18 @@ public class Properties extends AbstractMap<String, String> {
     }
 
     /**
+     * Copies all entries from the <code>java.util.Properties</code> object to this object
+     *
+     * @param properties a <code>java.util.Properties</code> object
+     * @throws NullPointerException if the properties parameter is null
+     */
+    public void putAll(java.util.Properties properties) {
+        for (Entry<Object, Object> entry : properties.entrySet()) {
+            put(entry.getKey().toString(), entry.getValue().toString());
+        }
+    }
+
+    /**
      * Returns a <code>java.util.Properties</code> with the same contents as this object. The
      * information is a copy, changes to one Properties object will not affect the other.
      *

--- a/src/test/java/org/codejive/properties/TestProperties.java
+++ b/src/test/java/org/codejive/properties/TestProperties.java
@@ -691,6 +691,15 @@ public class TestProperties {
         assertThat(sw.toString()).isEqualTo(readAll(getResource("/test-multidelim.properties")));
     }
 
+    @Test
+    void testPutAll() {
+        Properties p = new Properties();
+        java.util.Properties ju = new java.util.Properties();
+        ju.setProperty("foo", "bar");
+        p.putAll(ju);
+        assertThat(p.getProperty("foo")).isEqualTo("bar");
+    }
+
     private Path getResource(String name) throws URISyntaxException {
         return Paths.get(getClass().getResource(name).toURI());
     }


### PR DESCRIPTION
- This is useful when you need to copy all the values from a `java.util.Properties` to this structure
